### PR TITLE
New Ruby script to sign URLs.

### DIFF
--- a/urlsigner.rb
+++ b/urlsigner.rb
@@ -20,9 +20,13 @@ module GoogleUrlSigner
 
     def generate_signature(path, key)
       raw_key = url_safe_base64_decode(key)
-      digest = OpenSSL::Digest.new('sha1')
-      raw_signature = OpenSSL::HMAC.digest(digest, raw_key, path)
+      raw_signature = encrypt(raw_key, path)
       url_safe_base64_encode(raw_signature)
+    end
+
+    def encrypt(key, data)
+      digest = OpenSSL::Digest.new('sha1')
+      OpenSSL::HMAC.digest(digest, key, data)
     end
 
     def url_safe_base64_decode(base64_string)

--- a/urlsigner.rb
+++ b/urlsigner.rb
@@ -1,45 +1,43 @@
 #!/usr/bin/ruby
 # Test Script for Google Maps API signatures
 
-require 'rubygems'
 require 'base64'
+require 'openssl'
 require 'uri'
-# hmac, and hmac-sha1, are from # gem install ruby-hmac
-require 'hmac'
-require 'hmac-sha1'
 
-def urlSafeBase64Decode(base64String)
-  return Base64.decode64(base64String.tr('-_','+/'))
-end
+module GoogleUrlSigner
+  class << self
+    def sign(url, key)
+      parsed_url = URI.parse(url)
+      full_path = "#{parsed_url.path}?#{parsed_url.query}"
 
-def urlSafeBase64Encode(raw)
-  return Base64.encode64(raw).tr('+/','-_')
-end
+      signature = generate_signature(full_path, key)
 
+      "#{parsed_url.scheme}://#{parsed_url.host}#{full_path}&signature=#{signature}"
+    end
 
-def signURL(key, url)
-  parsedURL = URI.parse(url)
-  urlToSign = parsedURL.path + '?' + parsedURL.query
+    private
 
-  # Decode the private key
-  rawKey = urlSafeBase64Decode(key)
+    def generate_signature(path, key)
+      raw_key = url_safe_base64_decode(key)
+      digest = OpenSSL::Digest.new('sha1')
+      raw_signature = OpenSSL::HMAC.digest(digest, raw_key, path)
+      url_safe_base64_encode(raw_signature)
+    end
 
-  # create a signature using the private key and the URL
-  sha1 = HMAC::SHA1.new(rawKey)
-  sha1 << urlToSign
-  rawSignature = sha1.digest()
+    def url_safe_base64_decode(base64_string)
+      Base64.decode64(base64_string.tr('-_', '+/'))
+    end
 
-  # encode the signature into base64 for url use form.
-  signature =  urlSafeBase64Encode(rawSignature)
-
-  # prepend the server and append the signature.
-  signedUrl = parsedURL.scheme+"://"+ parsedURL.host + urlToSign + "&signature=#{signature}"
-  return signedUrl
+    def url_safe_base64_encode(raw)
+      Base64.encode64(raw).tr('+/', '-_').strip
+    end
+  end
 end
 
 # URL to sign
-url = "http://maps.google.com/maps/api/geocode/json?address=New+York&sensor=false&client=clientID"
+url = 'http://maps.google.com/maps/api/geocode/json?address=New+York&sensor=false&client=clientID'
 # Private Key
-PRIVATE_KEY = "vNIXE0xscrmjlyV-12Nj_BvUPaw="
+PRIVATE_KEY = 'vNIXE0xscrmjlyV-12Nj_BvUPaw='
 
-print signURL(PRIVATE_KEY, url)
+puts GoogleUrlSigner.sign(url, PRIVATE_KEY)


### PR DESCRIPTION
The same script in a Ruby way. 😄 
- Avoid `ruby-hmac` third part dependency;
- Use Ruby native `openssl`;
- Rewrite using Ruby conventions and style.